### PR TITLE
Send a list of available products when server details are requested

### DIFF
--- a/app/controllers/subscription_server/server_controller.rb
+++ b/app/controllers/subscription_server/server_controller.rb
@@ -7,12 +7,7 @@ class SubscriptionServer::ServerController < ApplicationController
     if SiteSetting.subscription_server_supplier_name.present?
       render json: success_json.merge(
         supplier: SiteSetting.subscription_server_supplier_name,
-        subscriptions: SubscriptionServer::Subscription.map.map do |resource_name, subscription|
-          {
-            resource_name: resource_name,
-            product_ids: subscription[:product_ids]
-          }
-        end
+        products: SubscriptionServer::Subscription.product_map
       )
     else
       render json: failed_json, status: 404

--- a/app/controllers/subscription_server/server_controller.rb
+++ b/app/controllers/subscription_server/server_controller.rb
@@ -5,7 +5,15 @@ class SubscriptionServer::ServerController < ApplicationController
 
   def index
     if SiteSetting.subscription_server_supplier_name.present?
-      render json: success_json.merge(supplier: SiteSetting.subscription_server_supplier_name)
+      render json: success_json.merge(
+        supplier: SiteSetting.subscription_server_supplier_name,
+        subscriptions: SubscriptionServer::Subscription.map.map do |resource_name, subscription|
+          {
+            resource_name: resource_name,
+            product_ids: subscription[:product_ids]
+          }
+        end
+      )
     else
       render json: failed_json, status: 404
     end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,7 +2,7 @@ en:
   site_settings:
     subscription_server_enabled: Enable subscription server
     subscription_server_supplier_name: Supplier name, e.g. "Pavilion"
-    subscription_server_subscriptions: "List of supported subscriptions. resource_name:provider_name:product_id:domain_limit e.g. custom-wizard:stripe:prod_Jyy6B9gyTJUURi:1"
+    subscription_server_subscriptions: "List of supported subscriptions. resource:product_slug:provider:product_id:domain_limit e.g. discourse-custom-wizard:business:stripe:prod_Jyy6B9gyTJUURi:1"
 
   user_api_key:
     scopes:

--- a/lib/subscription_server/subscription.rb
+++ b/lib/subscription_server/subscription.rb
@@ -15,4 +15,28 @@ class SubscriptionServer::Subscription
     @price_id = price_id
     @price_name = price_name
   end
+
+  def self.map
+    SiteSetting.subscription_server_subscriptions.split('|')
+      .reduce({}) do |result, str|
+        parts = str.split(':')
+
+        if parts.size >= 3
+          resource = parts[0]
+          provider = parts[1]
+          product_id = parts[2]
+          domain_limit = parts[3]
+
+          result[resource] ||= { provider: provider, product_ids: [] }
+          result[resource][:product_ids] << product_id
+
+          if domain_limit
+            result[resource][:domain_limits] ||= []
+            result[resource][:domain_limits] << { product_id: product_id, domain_limit: domain_limit.to_i }
+          end
+        end
+
+        result
+      end
+  end
 end

--- a/lib/subscription_server/subscription.rb
+++ b/lib/subscription_server/subscription.rb
@@ -16,19 +16,23 @@ class SubscriptionServer::Subscription
     @price_name = price_name
   end
 
-  def self.map
+  def self.subscription_map
     SiteSetting.subscription_server_subscriptions.split('|')
       .reduce({}) do |result, str|
         parts = str.split(':')
 
         if parts.size >= 3
           resource = parts[0]
-          provider = parts[1]
-          product_id = parts[2]
-          domain_limit = parts[3]
+          product_slug = parts[1]
+          provider = parts[2]
+          product_id = parts[3]
+          domain_limit = parts[4]
 
-          result[resource] ||= { provider: provider, product_ids: [] }
-          result[resource][:product_ids] << product_id
+          result[resource] ||= { provider: provider, products: [] }
+          result[resource][:products] << {
+            product_slug: product_slug,
+            product_id: product_id
+          }
 
           if domain_limit
             result[resource][:domain_limits] ||= []
@@ -38,5 +42,13 @@ class SubscriptionServer::Subscription
 
         result
       end
+  end
+
+  def self.product_map
+    result = {}
+    subscription_map.each do |resource, attrs|
+      result[resource] = attrs[:products]
+    end
+    result
   end
 end

--- a/lib/subscription_server/user_subscriptions.rb
+++ b/lib/subscription_server/user_subscriptions.rb
@@ -35,7 +35,7 @@ class SubscriptionServer::UserSubscriptions
     return unless resources.present? && @user.present? && @domain.present?
 
     resources.each do |resource|
-      sub_atts = SubscriptionServer::Subscription.map[resource]
+      sub_atts = SubscriptionServer::Subscription.subscription_map[resource]
       next handle_failure(resource, "no subscription found for #{resource}") unless sub_atts.present?
 
       klass = providers[sub_atts[:provider].to_sym]
@@ -45,7 +45,8 @@ class SubscriptionServer::UserSubscriptions
       next handle_failure(resource, "#{provider.name} is not installed") unless provider.installed?
       next handle_failure(resource, "failed to setup #{provider.name}") unless provider.setup
 
-      resource_subscriptions = provider.subscriptions(sub_atts[:product_ids], resource)
+      product_ids = sub_atts[:products].map { |p| p[:product_id] }
+      resource_subscriptions = provider.subscriptions(product_ids, resource)
       next handle_failure(resource, "no subscriptions found for #{resource}") unless resource_subscriptions.any?
 
       product_ids = resource_subscriptions.map(&:product_id)

--- a/lib/subscription_server/user_subscriptions.rb
+++ b/lib/subscription_server/user_subscriptions.rb
@@ -35,7 +35,7 @@ class SubscriptionServer::UserSubscriptions
     return unless resources.present? && @user.present? && @domain.present?
 
     resources.each do |resource|
-      sub_atts = subscriptions_map[resource]
+      sub_atts = SubscriptionServer::Subscription.map[resource]
       next handle_failure(resource, "no subscription found for #{resource}") unless sub_atts.present?
 
       klass = providers[sub_atts[:provider].to_sym]
@@ -62,36 +62,6 @@ class SubscriptionServer::UserSubscriptions
     end
 
     @subscriptions = subscriptions
-  end
-
-  def subscriptions_map
-    @subscriptions_map ||= begin
-      SiteSetting.subscription_server_subscriptions.split('|')
-        .reduce({}) do |result, str|
-          parts = str.split(':')
-
-          if parts.size >= 3
-            resource = parts[0]
-            provider = parts[1]
-            product_id = parts[2]
-            domain_limit = parts[3]
-
-            result[resource] ||= { provider: provider, product_ids: [] }
-            result[resource][:product_ids] << product_id
-
-            if domain_limit
-              result[resource][:domain_limits] ||= []
-              result[resource][:domain_limits] << { product_id: product_id, domain_limit: domain_limit.to_i }
-            end
-          end
-
-          result
-        end
-    end
-  end
-
-  def self.subscriptions_map
-    new.subscriptions_map
   end
 
   protected

--- a/plugin.rb
+++ b/plugin.rb
@@ -69,7 +69,7 @@ after_initialize do
   end
 
   add_to_class(:user, :subscription_domains) do
-    subscriptions_map = SubscriptionServer::Subscription.map
+    subscriptions_map = SubscriptionServer::Subscription.subscription_map
     subscription_domains = {}
 
     custom_fields

--- a/plugin.rb
+++ b/plugin.rb
@@ -69,7 +69,7 @@ after_initialize do
   end
 
   add_to_class(:user, :subscription_domains) do
-    subscriptions_map = SubscriptionServer::UserSubscriptions.subscriptions_map
+    subscriptions_map = SubscriptionServer::Subscription.map
     subscription_domains = {}
 
     custom_fields

--- a/spec/components/subscription_server/user_spec.rb
+++ b/spec/components/subscription_server/user_spec.rb
@@ -4,11 +4,12 @@ describe User do
   fab!(:user) { Fabricate(:user) }
   let(:provider) { "stripe" }
   let(:product_id) { "prod_CBTNpi3fqWWkq0" }
+  let(:product_slug) { "business" }
   let(:resource) { "custom_wizard" }
   let(:domain) { "demo.pavilion.tech" }
   let(:another_domain) { "another.pavilion.tech" }
   let(:domain_limit) { 1 }
-  let(:subscriptions) { "#{resource}:#{provider}:#{product_id}:#{domain_limit.to_s}" }
+  let(:subscriptions) { "#{resource}:#{product_slug}:#{provider}:#{product_id}:#{domain_limit.to_s}" }
 
   before do
     SiteSetting.subscription_server_subscriptions = subscriptions

--- a/spec/components/subscription_server/user_subscriptions_spec.rb
+++ b/spec/components/subscription_server/user_subscriptions_spec.rb
@@ -5,8 +5,9 @@ describe SubscriptionServer::UserSubscriptions do
   let(:provider) { "stripe" }
   let(:invalid_provider) { "braintree" }
   let(:product_id) { "prod_CBTNpi3fqWWkq0" }
+  let(:product_slug) { "business" }
   let(:resource) { "custom_wizard" }
-  let(:subscriptions) { "#{resource}:#{provider}:#{product_id}" }
+  let(:subscriptions) { "#{resource}:#{product_slug}:#{provider}:#{product_id}" }
   let(:resources) { [resource] }
   let(:domain) { "demo.pavilion.tech" }
 

--- a/spec/requests/subscription_server/server_controller_spec.rb
+++ b/spec/requests/subscription_server/server_controller_spec.rb
@@ -3,6 +3,7 @@
 describe SubscriptionServer::ServerController do
   let(:provider) { "stripe" }
   let(:product_id) { "prod_CBTNpi3fqWWkq0" }
+  let(:product_slug) { "business" }
   let(:resource) { "custom_wizard" }
 
   it "returns a 404 if the server details are not set" do
@@ -12,15 +13,19 @@ describe SubscriptionServer::ServerController do
 
   it "returns server details" do
     SiteSetting.subscription_server_supplier_name = "Pavilion"
-    SiteSetting.subscription_server_subscriptions = "#{resource}:#{provider}:#{product_id}"
+    SiteSetting.subscription_server_subscriptions = "#{resource}:#{product_slug}:#{provider}:#{product_id}"
     get "/subscription-server"
     expect(response.status).to eq(200)
     expect(response.parsed_body["supplier"]).to eq("Pavilion")
-    expect(response.parsed_body["subscriptions"]).to eq([
+    expect(response.parsed_body["products"]).to eq(
       {
-        resource_name: resource,
-        product_ids: [product_id]
+        "#{resource}": [
+          {
+            product_slug: product_slug,
+            product_id: product_id
+          }
+        ]
       }.as_json
-    ])
+    )
   end
 end

--- a/spec/requests/subscription_server/server_controller_spec.rb
+++ b/spec/requests/subscription_server/server_controller_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 describe SubscriptionServer::ServerController do
+  let(:provider) { "stripe" }
+  let(:product_id) { "prod_CBTNpi3fqWWkq0" }
+  let(:resource) { "custom_wizard" }
+
   it "returns a 404 if the server details are not set" do
     get "/subscription-server"
     expect(response.status).to eq(404)
@@ -8,8 +12,15 @@ describe SubscriptionServer::ServerController do
 
   it "returns server details" do
     SiteSetting.subscription_server_supplier_name = "Pavilion"
+    SiteSetting.subscription_server_subscriptions = "#{resource}:#{provider}:#{product_id}"
     get "/subscription-server"
     expect(response.status).to eq(200)
     expect(response.parsed_body["supplier"]).to eq("Pavilion")
+    expect(response.parsed_body["subscriptions"]).to eq([
+      {
+        resource_name: resource,
+        product_ids: [product_id]
+      }.as_json
+    ])
   end
 end


### PR DESCRIPTION
This is necessary to allow for a multi-environment (e.g. test) subscription system, as it allows products to be mapped to slugs on the server itself, instead of product ids being hard-coded in the plugin (e.g. the custom wizard plugin).